### PR TITLE
Fixes issue #2

### DIFF
--- a/backbone.touch.js
+++ b/backbone.touch.js
@@ -42,12 +42,13 @@
                 if (!method) throw new Error('Method "' + events[key] + '" does not exist');
                 var match = key.match(delegateEventSplitter);
                 var eventName = match[1], selector = match[2];
+                var boundHandler = _.bind(this._touchHandler,this);
                 method = _.bind(method, this);
                 if (this.isTouch && eventName === 'click' && selector !== '') {
-                    this.$el.on('touchstart' + suffix, selector, this._touchHandler);
+                    this.$el.on('touchstart' + suffix, selector, boundHandler);
                     this.$el.on('touchend' + suffix, selector,
                         {method:method},
-                        this._touchHandler
+                        boundHandler
                     );
                 }
                 else {


### PR DESCRIPTION
This fixes the problem mentioned in issue #2, where ghost clicks still occured. If I'm right, it was caused by the touchHandler being executed in context of the clicked element, not the view. Thus the `if (this.touchPrevens)`check would always fail.
