### PR TITLE
 Cannot read property 'document' of undefined

### DIFF
--- a/backbone.touch.js
+++ b/backbone.touch.js
@@ -31,7 +31,7 @@
 
         touchPrevents : true,
 
-        isTouch : 'ontouchstart' in this.document,
+        isTouch : 'ontouchstart' in document,
 
         // Drop in replacement for Backbone.View#delegateEvent
         // Enables better touch support


### PR DESCRIPTION
I'm seeing an error testing on Mobile Safari and desktop Chrome -- 

```
Uncaught TypeError: Cannot read property 'document' of undefined backbone.touch.js:34
```

The call to check if touch support is there is looking for a "this.document". Removing the "this" fixes it.
