### PR TITLE
Support for devices with both a mouse and touch events

### DIFF
--- a/backbone.touch.js
+++ b/backbone.touch.js
@@ -66,6 +66,24 @@
                     }
                 }
             }, this);
+
+            // If we think we are touch listen out for a mousemove event
+            // which could indicate we are a device with both touch and
+            // mouse, eg Chromebook Pixel
+            if (this.isTouch) {
+                var self = this;
+                var mouseMove = function(event) {
+                    self.isTouch = false;
+                    self.delegateEvents(events);
+                    document.removeEventListener('mousemove', mouseMove);
+                };
+                var touchStart = function(event) {
+                    document.removeEventListener('mousemove', mouseMove);
+                    document.removeEventListener('touchstart', touchStart);
+                };
+                document.addEventListener('touchstart', touchStart);
+                document.addEventListener('mousemove', mouseMove);
+            }
         },
 
         // Detect if touch handlers should be used over listening for click


### PR DESCRIPTION
At the moment backbone.touch doesn't play nicely with devices that have both a touch event and a mouse available. I believe this change will help to alleviate this problem, however I don't have many devices to test on. Can you take a look and see if you think this will help?

My issue has occurred within my application with users who have a Chromebook Pixel not being able to click on any links with the mouse pad. I don't have a Chromebook Pixel to test on either, but I will be pushing out this change to my users to see if it fixes it.

Cheers!
