### PR TITLE
replaced chain with direct function call for lodash compatibility

### DIFF
--- a/backbone.touch.js
+++ b/backbone.touch.js
@@ -48,7 +48,7 @@
             if (!(events || (events = getValue(this, 'events')))) return;
             this.undelegateEvents();
             var suffix = '.delegateEvents' + this.cid;
-            _(events).each(function(method, key) {
+            _.each(events, function(method, key) {
                 if (!_.isFunction(method)) method = this[events[key]];
                 if (!method) throw new Error('Method "' + events[key] + '" does not exist');
                 var match = key.match(delegateEventSplitter);

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "backbone.touch",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "main": "./backbone.touch.js",
     "ignore": ["test/*"],
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backbone.touch",
   "description": "Enable faster click events on touch devices for Backbone views.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "homepage": "https://github.com/nervetattoo/backbone.touch",
   "main": "backbone.touch.js",
   "author": {


### PR DESCRIPTION
This is my second attempt at a pull request- apologies if it's done incorrectly, I've never made a pull request before.

I was attempting to run this script in a project using lodash in place of underscore, and it was failing due to the differing syntax between chained function calls. lodash expects you to invoke `.value` at the end of a chain in which nothing is returned.

My solution was to replace the chain with a direct invocation of `_.each` because the chaining appeared to be unimportant.
